### PR TITLE
feat: tmdb match stratigy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4603,6 +4603,7 @@ dependencies = [
  "tmdb-api",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/metadata/src/fetcher.rs
+++ b/crates/metadata/src/fetcher.rs
@@ -120,10 +120,10 @@ impl Fetcher {
                 .await?;
         } else {
             warn!("未在 bangumi.tv 找到番剧信息: {}", bgm.name);
-            // 如果没有封面，尝试从 mikan 获取
-            if bgm.poster_image_url.is_none() {
-                self.fetch_image_from_mikan(bgm, mikan_info).await?;
-            }
+        }
+        // 如果没有封面，尝试从 mikan 获取
+        if bgm.poster_image_url.is_none() {
+            self.fetch_image_from_mikan(bgm, mikan_info).await?;
         }
         Ok(())
     }

--- a/libs/bangumi-tv/src/client.rs
+++ b/libs/bangumi-tv/src/client.rs
@@ -37,9 +37,8 @@ impl Client {
             .await?
             .text()
             .await?;
-        let resp: Vec<CalendarResponse> = serde_json::from_str(&response).with_context(|| {
-            format!("解析放送列表失败: {}", response)
-        })?;
+        let resp: Vec<CalendarResponse> = serde_json::from_str(&response)
+            .with_context(|| format!("解析放送列表失败: {}", response))?;
         Ok(resp)
     }
 
@@ -65,9 +64,8 @@ impl Client {
             .await?
             .text()
             .await?;
-        let resp: EpisodeList = serde_json::from_str(&response).with_context(|| {
-            format!("解析剧集信息失败: {}", response)
-        })?;
+        let resp: EpisodeList = serde_json::from_str(&response)
+            .with_context(|| format!("解析剧集信息失败: {}", response))?;
         Ok(resp)
     }
 
@@ -81,9 +79,8 @@ impl Client {
             .await?
             .text()
             .await?;
-        let resp: Subject = serde_json::from_str(&response).with_context(|| {
-            format!("解析番剧信息失败: {}", response)
-        })?;
+        let resp: Subject = serde_json::from_str(&response)
+            .with_context(|| format!("解析番剧信息失败: {}", response))?;
         Ok(Some(resp))
     }
 }

--- a/libs/tmdb/Cargo.toml
+++ b/libs/tmdb/Cargo.toml
@@ -19,3 +19,4 @@ lazy_static = {workspace = true}
 
 [dev-dependencies]
 dotenv = {workspace = true}
+tracing-subscriber = {workspace = true}


### PR DESCRIPTION
增强TMDB 匹配策略

1. 尝试使用放送日期的年月去匹配TV
2. 尝试使用放送日期的年月去匹配季
3. 如果上面两者都无法判定，那么就遍历所有剧集，根据剧集来判断