### PR TITLE
fix: metadata  update

### DIFF
--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 mod db;
 pub mod fetcher;
+mod matcher;
 mod mdb_bgmtv;
 mod mdb_mikan;
 mod mdb_tmdb;

--- a/crates/metadata/src/matcher.rs
+++ b/crates/metadata/src/matcher.rs
@@ -12,6 +12,17 @@ pub struct Matcher {
 }
 
 impl Matcher {
+    pub fn new(
+        tmdb: tmdb::client::Client,
+        bgm_tv: bangumi_tv::client::Client,
+        mikan: mikan::client::Client,
+    ) -> Self {
+        Self {
+            tmdb,
+            bgm_tv,
+            mikan,
+        }
+    }
     pub async fn match_tmdb(
         &self,
         bgm: &mut bangumi::Model,

--- a/crates/metadata/src/matcher.rs
+++ b/crates/metadata/src/matcher.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use bangumi_tv::model::Subject;
+use model::bangumi;
+use tmdb::api::tvshow::{SeasonShort, TVShow};
+use tracing::{info, warn};
+
+#[derive(Clone)]
+pub struct Matcher {
+    pub tmdb: tmdb::client::Client,
+    pub bgm_tv: bangumi_tv::client::Client,
+    pub mikan: mikan::client::Client,
+}
+
+impl Matcher {
+    pub async fn match_tmdb(
+        &self,
+        bgm: &mut bangumi::Model,
+    ) -> Result<Option<(TVShow, SeasonShort)>> {
+        info!("尝试匹配 TMDB: {}", bgm.name);
+        let air_date = bgm.air_date.map(|dt| dt.and_utc().date_naive());
+        self.tmdb.match_bangumi(&bgm.name, air_date).await
+    }
+
+    pub async fn match_bgm_tv(
+        &self,
+        bgm: &mut bangumi::Model,
+        loaded: bool,
+    ) -> Result<Option<Subject>> {
+        info!("尝试匹配 bgm.tv: {}", bgm.name);
+        if bgm.mikan_id.is_none() {
+            warn!("[MIKAN] 没有 mikan_id ，跳过匹配");
+            return Ok(None);
+        }
+
+        let info = self.mikan.get_bangumi_info(bgm.mikan_id.unwrap()).await?;
+        bgm.bangumi_tv_id = info.bangumi_tv_id;
+
+        if loaded {
+            return Ok(None);
+        }
+
+        let subject = self.bgm_tv.get_subject(bgm.bangumi_tv_id.unwrap()).await?;
+        Ok(subject)
+    }
+}

--- a/crates/metadata/src/mdb_bgmtv.rs
+++ b/crates/metadata/src/mdb_bgmtv.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use model::bangumi;
 use tokio::fs;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[derive(Clone)]
 pub struct MdbBgmTV {
@@ -21,7 +21,8 @@ impl MetadataDb for MdbBgmTV {
     ) -> Result<()> {
         info!("[bgm.tv] 填充番剧元数据: {}", bgm.name);
         if bgm.bangumi_tv_id.is_none() {
-            return Err(anyhow::anyhow!("番剧TV ID为空"));
+            warn!("[bgm.tv] 没有 bangumi_tv_id，跳过更新");
+            return Ok(());
         }
 
         let need_update = bgm.ep_count == 0

--- a/crates/metadata/src/mdb_mikan.rs
+++ b/crates/metadata/src/mdb_mikan.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use model::bangumi;
 use tokio::fs;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::{format_poster_image_file_name, MetadataAttr, MetadataAttrSet, MetadataDb};
 
@@ -23,7 +23,8 @@ impl MetadataDb for MdbMikan {
         info!("[MIKAN] 填充番剧元数据: {}", bgm.name);
 
         if bgm.mikan_id.is_none() {
-            return Err(anyhow::anyhow!("番剧缺少mikan_id"));
+            warn!("[MIKAN] 没有mikan_id，跳过更新");
+            return Ok(());
         }
 
         let need_update = bgm.bangumi_tv_id.is_none() || bgm.poster_image_url.is_none() || force;

--- a/crates/metadata/src/worker.rs
+++ b/crates/metadata/src/worker.rs
@@ -244,22 +244,6 @@ impl Worker {
 
         // NOTE: 这里需要考虑外部服务被重复访问
 
-        // 1. 先使用 mikan 填充 bgm_tv_id
-        match mdbs
-            .mikan
-            .update_bangumi_metadata(
-                &mut bgm,
-                MetadataAttrSet(vec![MetadataAttr::BgmTvId]),
-                force,
-            )
-            .await
-        {
-            Ok(_) => {}
-            Err(e) => {
-                error!("使用mikan填充bgm_tv_id失败: {}", e);
-            }
-        }
-
         // 2. 使用Tmdb填充绝大部分信息
         match mdbs
             .tmdb
@@ -279,7 +263,7 @@ impl Worker {
         }
         match mdbs
             .bgmtv
-            .update_bangumi_metadata(&mut bgm, attrs, force)
+            .update_bangumi_metadata(&mut bgm, attrs, false)
             .await
         {
             Ok(_) => {}
@@ -295,7 +279,7 @@ impl Worker {
                 .update_bangumi_metadata(
                     &mut bgm,
                     MetadataAttrSet(vec![MetadataAttr::Poster]),
-                    force,
+                    false,
                 )
                 .await
             {


### PR DESCRIPTION
close: #64 

1. 正确处理元数据更新顺序
2. 减少没必要的tmdb 匹配逻辑，只在刷新calendar时进行匹配其它mdb