### PR TITLE
feat: add subscrition setting for enforce torrent release time after episode airdate

### DIFF
--- a/crates/model/src/entity/subscriptions.rs
+++ b/crates/model/src/entity/subscriptions.rs
@@ -18,6 +18,7 @@ pub struct Model {
     pub updated_at: DateTime,
     pub collector_interval: Option<i32>,
     pub metadata_interval: Option<i32>,
+    pub enforce_torrent_release_after_broadcast: i8,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/scheduler/src/db.rs
+++ b/crates/scheduler/src/db.rs
@@ -370,6 +370,7 @@ impl Db {
         release_group_filter: Option<String>,
         collector_interval: Option<i32>,
         metadata_interval: Option<i32>,
+        enforce_torrent_release_after_broadcast: bool,
     ) -> Result<()> {
         use model::subscriptions::Column as SubscriptionColumn;
         use model::subscriptions::Entity as Subscriptions;
@@ -383,6 +384,9 @@ impl Db {
             collector_interval: Set(collector_interval),
             metadata_interval: Set(metadata_interval),
             start_episode_number: Set(start_episode_number),
+            enforce_torrent_release_after_broadcast: Set(
+                enforce_torrent_release_after_broadcast as i8
+            ),
             ..Default::default()
         };
 
@@ -397,6 +401,7 @@ impl Db {
                     .update_column(SubscriptionColumn::CollectorInterval)
                     .update_column(SubscriptionColumn::MetadataInterval)
                     .update_column(SubscriptionColumn::StartEpisodeNumber)
+                    .update_column(SubscriptionColumn::EnforceTorrentReleaseAfterBroadcast)
                     .to_owned(),
             )
             .exec(self.conn())

--- a/crates/scheduler/src/subscribe.rs
+++ b/crates/scheduler/src/subscribe.rs
@@ -14,6 +14,7 @@ impl Scheduler {
         release_group_filter: Option<String>,
         collector_interval: Option<i32>,
         metadata_interval: Option<i32>,
+        enforce_torrent_release_after_broadcast: bool,
     ) -> Result<()> {
         // 将分辨率列表转换为逗号分隔的字符串
         let resolution_filter_str = resolution_filter.map(|resolutions| {
@@ -80,6 +81,7 @@ impl Scheduler {
                 release_group_filter,
                 collector_interval,
                 metadata_interval,
+                enforce_torrent_release_after_broadcast,
             )
             .await
             .context("更新订阅状态失败")?;

--- a/crates/scheduler/src/worker.rs
+++ b/crates/scheduler/src/worker.rs
@@ -87,10 +87,12 @@ impl BangumiWorker {
                     }
 
                     // 确保种子发布时间在番剧集数发布时间之后
-                    if let Some(episode) = episodes.get(&actual_ep) {
-                        if let Some(air_date) = episode.air_date {
-                            if torrent.pub_date < air_date.into() {
-                                return false;
+                    if self.sub.enforce_torrent_release_after_broadcast == 1 {
+                        if let Some(episode) = episodes.get(&actual_ep) {
+                            if let Some(air_date) = episode.air_date {
+                                if torrent.pub_date < air_date.into() {
+                                    return false;
+                                }
                             }
                         }
                     }

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -66,6 +66,7 @@ pub async fn calendar(
         .column(SubscriptionColumn::ResolutionFilter)
         .column(SubscriptionColumn::LanguageFilter)
         .column(SubscriptionColumn::ReleaseGroupFilter)
+        .column(SubscriptionColumn::EnforceTorrentReleaseAfterBroadcast)
         // 联表查询
         .join_rev(
             JoinType::LeftJoin,
@@ -134,6 +135,7 @@ pub async fn get_bangumi_by_id(
         .column(SubscriptionColumn::ResolutionFilter)
         .column(SubscriptionColumn::LanguageFilter)
         .column(SubscriptionColumn::ReleaseGroupFilter)
+        .column(SubscriptionColumn::EnforceTorrentReleaseAfterBroadcast)
         // 联表查询
         .join_rev(
             JoinType::LeftJoin,

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -265,6 +265,7 @@ pub async fn subscribe_bangumi(
                     params.release_group_filter.clone(),
                     params.collector_interval,
                     params.metadata_interval,
+                    params.enforce_torrent_release_after_broadcast,
                 )
                 .await?;
         }

--- a/crates/server/src/model.rs
+++ b/crates/server/src/model.rs
@@ -60,6 +60,8 @@ pub struct Bangumi {
     pub resolution_filter: Option<String>,
     pub language_filter: Option<String>,
     pub release_group_filter: Option<String>,
+    #[sea_orm(column_type = "Boolean")]
+    pub enforce_torrent_release_after_broadcast: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, FromQueryResult)]
@@ -114,6 +116,7 @@ pub struct SubscribeParams {
     pub release_group_filter: Option<String>,
     pub collector_interval: Option<i32>,
     pub metadata_interval: Option<i32>,
+    #[serde(default)]
     pub enforce_torrent_release_after_broadcast: bool,
 }
 

--- a/crates/server/src/model.rs
+++ b/crates/server/src/model.rs
@@ -114,6 +114,7 @@ pub struct SubscribeParams {
     pub release_group_filter: Option<String>,
     pub collector_interval: Option<i32>,
     pub metadata_interval: Option<i32>,
+    pub enforce_torrent_release_after_broadcast: bool,
 }
 
 // 定义一个结构体来接收查询结果

--- a/develop/migrations/V1.0.3__sub_option.sql
+++ b/develop/migrations/V1.0.3__sub_option.sql
@@ -1,0 +1,2 @@
+alter table subscriptions
+    add enforce_torrent_release_after_broadcast bool default true not null;

--- a/web/src/api/model.ts
+++ b/web/src/api/model.ts
@@ -59,6 +59,7 @@ export interface SubscribeParams {
   release_group_filter?: string | undefined
   collector_interval?: number | undefined
   metadata_interval?: number | undefined
+  enforce_torrent_release_after_broadcast?: boolean | undefined
 }
 
 // 番剧信息
@@ -83,6 +84,7 @@ export interface Bangumi {
   resolution_filter: string | null
   language_filter: string | null
   release_group_filter: string | null
+  enforce_torrent_release_after_broadcast: boolean | null
 }
 
 // 剧集信息

--- a/web/src/components/SubscribeDialog.vue
+++ b/web/src/components/SubscribeDialog.vue
@@ -59,7 +59,8 @@ const formData = ref({
     : 30,
   metadata_interval: props.currentSubscribeSettings?.metadata_interval
     ? Math.floor(props.currentSubscribeSettings.metadata_interval / 60)
-    : 60
+    : 60,
+  enforce_torrent_release_after_broadcast: props.currentSubscribeSettings?.enforce_torrent_release_after_broadcast ?? true
 })
 
 interface Resolution {
@@ -103,7 +104,8 @@ function onSubmit() {
       : undefined,
     metadata_interval: formData.value.metadata_interval
       ? formData.value.metadata_interval * 60
-      : undefined
+      : undefined,
+    enforce_torrent_release_after_broadcast: formData.value.enforce_torrent_release_after_broadcast
   }
   emit('subscribe', params)
   emit('update:modelValue', false)
@@ -173,7 +175,7 @@ function unsubscribe() {
               class="input-field"
             >
               <template v-slot:chip="{ props, item }">
-                <v-chip v-bind="props" :text="String(item.raw)" size="x-small" label />
+                <v-chip v-bind="props" :text="item.raw.text" size="x-small" label />
               </template>
             </v-select>
           </div>
@@ -197,7 +199,7 @@ function unsubscribe() {
               class="input-field"
             >
               <template v-slot:chip="{ props, item }">
-                <v-chip v-bind="props" :text="String(item.raw)" size="x-small" label />
+                <v-chip v-bind="props" :text="item.raw.text" size="x-small" label />
               </template>
             </v-select>
           </div>
@@ -272,6 +274,20 @@ function unsubscribe() {
               placeholder="默认 60 分钟"
             >
             </v-text-field>
+          </div>
+
+          <div class="input-group mt-2">
+            <div class="input-label">
+              <v-icon icon="mdi-filter-check" color="primary" size="16" class="me-2" />
+              <span>严格选取种子: 确保种子发布时间在剧集放送后</span>
+            </div>
+            <v-switch
+              v-model="formData.enforce_torrent_release_after_broadcast"
+              color="primary"
+              hide-details
+              density="compact"
+              size="small"
+            ></v-switch>
           </div>
         </v-form>
       </v-card-text>


### PR DESCRIPTION
close: #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了新的订阅选项，允许用户选择是否在剧集播出后才触发Torrent发布。  
	- 订阅界面新增了开关控件，使用户能轻松管理这一设置。
	- 系统各层（包括数据库、后端逻辑和前端界面）均已更新，以支持此功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->