### PR TITLE
feat(scheduler): 在获取番剧种子时包含种子来源信息

### DIFF
--- a/crates/scheduler/src/db.rs
+++ b/crates/scheduler/src/db.rs
@@ -208,6 +208,7 @@ impl Db {
                 TorrentColumn::InfoHash,
                 TorrentColumn::Magnet,
                 TorrentColumn::PubDate,
+                TorrentColumn::Source,
             ])
             .filter(TorrentColumn::BangumiId.eq(bangumi_id))
             .join(
@@ -436,7 +437,7 @@ mod tests {
             .with_target(true)
             .init();
         let db = Db::new_from_env().await?;
-        let torrents = db.get_bangumi_torrents_with_parse_results(91).await?;
+        let torrents = db.get_bangumi_torrents_with_parse_results(478).await?;
         let info_hashes = torrents
             .iter()
             .map(|t| t.0.info_hash.clone())


### PR DESCRIPTION
此次修改在数据库查询中添加了 TorrentColumn::Source 列，以便在获取番剧种子时能够检索和返回种子的来源信息。同时，测试用例中的 bangumi_id 也被更新为 478。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 数据查询功能现已扩展，用户将获得更详细的 torrent 数据信息，包括新增的来源数据，提升查询结果的完整性与实用性。

- **测试**
  - 更新了测试用例，通过调整查询标识验证新数据展示效果，确保功能改进后系统响应准确无误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->