### PR TITLE
feat(downloader): 为第三方下载器添加文件删除选项

### DIFF
--- a/crates/downloader/src/lib.rs
+++ b/crates/downloader/src/lib.rs
@@ -56,7 +56,7 @@ pub trait ThirdPartyDownloader: Send + Sync {
         result: Option<String>,
     ) -> Result<DownloadInfo>;
     async fn cancel_task(&self, info_hash: &str) -> Result<()>;
-    async fn remove_task(&self, info_hash: &str) -> Result<()>;
+    async fn remove_task(&self, info_hash: &str, remove_files: bool) -> Result<()>;
 }
 
 #[async_trait]

--- a/crates/downloader/src/thirdparty/pan_115_impl.rs
+++ b/crates/downloader/src/thirdparty/pan_115_impl.rs
@@ -192,8 +192,10 @@ impl ThirdPartyDownloader for Pan115DownloaderImpl {
         Ok(())
     }
 
-    async fn remove_task(&self, info_hash: &str) -> Result<()> {
-        self.pan115.delete_offline_task(&[info_hash], true).await?;
+    async fn remove_task(&self, info_hash: &str, remove_files: bool) -> Result<()> {
+        self.pan115
+            .delete_offline_task(&[info_hash], remove_files)
+            .await?;
         Ok(())
     }
 }

--- a/crates/downloader/src/worker.rs
+++ b/crates/downloader/src/worker.rs
@@ -390,7 +390,7 @@ impl Worker {
         );
 
         debug!("从第三方下载器移除失败任务: info_hash={}", info_hash);
-        if let Err(e) = self.downloader.remove_task(&info_hash).await {
+        if let Err(e) = self.downloader.remove_task(&info_hash, true).await {
             warn!("移除失败任务出错: info_hash={}, 错误: {}", info_hash, e);
         }
 
@@ -441,7 +441,7 @@ impl Worker {
             self.config.max_retry_count
         );
         // 删除原有任务，然后重新下载
-        if let Err(e) = self.downloader.remove_task(&info_hash).await {
+        if let Err(e) = self.downloader.remove_task(&info_hash, true).await {
             warn!("移除任务准备重试出错: info_hash={}, 错误: {}", info_hash, e);
         }
 

--- a/crates/downloader/tests/test_worker.rs
+++ b/crates/downloader/tests/test_worker.rs
@@ -38,7 +38,9 @@ fn create_mock_downloader() -> MockThirdPartyDownloader {
         .returning(|| "mock_downloader");
     mock_downloader.expect_cancel_task().returning(|_| Ok(()));
 
-    mock_downloader.expect_remove_task().returning(|_| Ok(()));
+    mock_downloader
+        .expect_remove_task()
+        .returning(|_, _| Ok(()));
 
     mock_downloader
 }


### PR DESCRIPTION
更新了 ThirdPartyDownloader trait 和相关实现，为 remove_task 方法新增 remove_files 参数，允许在移除下载任务时控制是否同时删除已下载文件。同时更新了相关测试用例以适配新的方法签名。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 任务删除功能现已升级，用户在移除任务时可选择是否同时删除关联文件，从而实现更灵活、彻底的任务和文件管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->