### PR TITLE
feat(server): 集成 Sentry 错误追踪和监控

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1357,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "flate2"
@@ -1748,6 +1770,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -2775,6 +2808,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5"
+dependencies = [
+ "log",
+ "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ouroboros"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,6 +3530,7 @@ dependencies = [
  "cookie 0.18.1",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.7",
@@ -3972,6 +4017,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
+name = "sentry"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565ec31ad37bab8e6d9f289f34913ed8768347b133706192f10606dabd5c6bc4"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e860275f25f27e8c0c7726ce116c7d5c928c5bba2ee73306e52b20a752298ea6"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653942e6141f16651273159f4b8b1eaeedf37a7554c00cd798953e64b8a9bf72"
+dependencies = [
+ "once_cell",
+ "rand 0.8.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60bc2154e6df59beed0ac13d58f8dfaf5ad20a88548a53e29e4d92e8e835c2"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105e3a956c8aa9dab1e4087b1657b03271bfc49d838c6ae9bfc7c58c802fd0ef"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e75c831b4d8b34a5aec1f65f67c5d46a26c7c5d3c7abd8b5ef430796900cf8"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4203359e60724aa05cf2385aaf5d4f147e837185d7dd2b9ccf1ee77f4420c8"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4110,6 +4263,8 @@ dependencies = [
  "scheduler",
  "sea-orm",
  "sea-orm-migration",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "sysinfo",
@@ -4592,7 +4747,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -5169,6 +5324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,6 +5382,19 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url",
+]
 
 [[package]]
 name = "url"
@@ -5477,6 +5654,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,3 +110,5 @@ mockall = "0.13.1"
 
 # 静态哈希表
 phf = { version = "0.11", features = ["macros"] }
+sentry = "0.36.0"
+sentry-tracing = "0.36.0"

--- a/crates/cli-app/Cargo.toml
+++ b/crates/cli-app/Cargo.toml
@@ -16,3 +16,4 @@ anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 server = { path = "../server"}
 jemallocator = { workspace = true }
+tracing = { workspace = true }

--- a/crates/cli-app/src/main.rs
+++ b/crates/cli-app/src/main.rs
@@ -40,7 +40,7 @@ pub async fn main() -> Result<()> {
             Ok(_) => {}
             Err(e) => {
                 tracing::error!("服务启动失败，错误原因: {}", e);
-                std::process::exit(-1);
+                std::process::exit(1);
             }
         },
     }

--- a/crates/cli-app/src/main.rs
+++ b/crates/cli-app/src/main.rs
@@ -36,9 +36,13 @@ pub async fn main() -> Result<()> {
     setup_panic_hook();
 
     match cli.commands {
-        Commands::Start => {
-            server::Server::new(config, writer).await?.serve().await?;
-        }
+        Commands::Start => match server::Server::new(config, writer).await?.serve().await {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("服务启动失败，错误原因: {}", e);
+                std::process::exit(-1);
+            }
+        },
     }
     Ok(())
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -5,42 +5,52 @@ edition = "2021"
 
 [dependencies]
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true , features = ["env-filter"]}
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-serde = {workspace = true, features = ["derive"]}
-serde_json = {workspace = true}
-actix-web = {workspace = true}
-actix-files = {workspace = true}
-actix-cors  = {workspace = true}
-actix-ws = {workspace = true}
-tracing-actix-web = {workspace = true}
-console-subscriber = {workspace = true, optional = true}
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+actix-web = { workspace = true }
+actix-files = { workspace = true }
+actix-cors = { workspace = true }
+actix-ws = { workspace = true }
+tracing-actix-web = { workspace = true }
+console-subscriber = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-stream = {workspace = true}
-tokio_schedule = {workspace = true}
+tokio-stream = { workspace = true }
+tokio_schedule = { workspace = true }
 reqwest = { workspace = true }
 chrono = { workspace = true }
-tmdb-api = {workspace = true}
+tmdb-api = { workspace = true }
 # services = { path = "../services" }
 tmdb = { path = "../../libs/tmdb" }
 bangumi-tv = { path = "../../libs/bangumi-tv" }
-parser = {path = "../parser"}
-metadata = {path = "../metadata"}
-downloader = {path = "../downloader"}
-mikan = {path = "../../libs/mikan" }
-pan-115 = {path = "../../libs/pan-115" }
-model = {path = "../model"}
-scheduler = {path = "../scheduler"}
-sea-orm = {workspace = true, features = [ "sqlx-mysql", "runtime-tokio-rustls", "macros", "debug-print"]}
-sea-orm-migration = {workspace = true, features = ["sqlx-mysql", "runtime-tokio-rustls"]}
-notify = {path = "../notify"}
-dict = {path = "../dict"}
-sysinfo = {workspace = true}
+parser = { path = "../parser" }
+metadata = { path = "../metadata" }
+downloader = { path = "../downloader" }
+mikan = { path = "../../libs/mikan" }
+pan-115 = { path = "../../libs/pan-115" }
+model = { path = "../model" }
+scheduler = { path = "../scheduler" }
+sea-orm = { workspace = true, features = [
+    "sqlx-mysql",
+    "runtime-tokio-rustls",
+    "macros",
+    "debug-print",
+] }
+sea-orm-migration = { workspace = true, features = [
+    "sqlx-mysql",
+    "runtime-tokio-rustls",
+] }
+notify = { path = "../notify" }
+dict = { path = "../dict" }
+sysinfo = { workspace = true }
 humantime-serde = "1.1.1"
+sentry-tracing = { workspace = true }
+sentry = { workspace = true }
 [dev-dependencies]
-dotenv = {workspace = true}
-tracing-subscriber = { workspace = true}
+dotenv = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [features]
 tokio_console = ["console-subscriber"]

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub downloader: DownloaderConfig,
     pub notify: NotifyConfig,
     pub proxy: ProxyConfig,
+    pub sentry: SentryConfig,
 }
 impl Config {
     pub fn validate(&self) -> Result<()> {
@@ -29,6 +30,7 @@ impl Config {
         self.downloader.validate()?;
         self.notify.validate()?;
         self.proxy.validate()?;
+        self.sentry.validate()?;
         Ok(())
     }
 }
@@ -415,6 +417,30 @@ impl BangumiTvConfig {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct SentryConfig {
+    pub enabled: bool,
+    pub dsn: String,
+}
+
+impl Default for SentryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dsn: "".to_owned(),
+        }
+    }
+}
+
+impl SentryConfig {
+    fn validate(&self) -> Result<()> {
+        if self.enabled {
+            validate_url(&self.dsn, "sentry.dsn")?;
+        }
+        Ok(())
+    }
+}
 // 将 chrono::Duration 转换为 std::time::Duration 进行序列化
 fn serialize_chrono_duration<S>(duration: &ChronoDuration, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/crates/server/src/logger.rs
+++ b/crates/server/src/logger.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use crate::config::Config;
 use anyhow::Result;
-use sentry_tracing::EventFilter;
 use tokio::sync::broadcast;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::{EnvFilter, Layer};
@@ -62,8 +61,8 @@ pub fn init_logger(config: &Config) -> Result<broadcast::Sender<LogMessage>> {
             ));
 
             let sentry_layer = sentry_tracing::layer().event_filter(|md| match md.level() {
-                &tracing::Level::ERROR => EventFilter::Event,
-                _ => EventFilter::Ignore,
+                &tracing::Level::ERROR => sentry_tracing::EventFilter::Event,
+                _ => sentry_tracing::EventFilter::Ignore,
             });
 
             let subscriber = tracing_subscriber::registry()

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1,5 +1,6 @@
 use actix_cors::Cors;
 use actix_web::{App, HttpServer};
+use core::panic;
 use dict::DictCode;
 use metadata::providers::mikan::MikanProvider;
 use parser::Parser;


### PR DESCRIPTION
close: #226

- 添加 Sentry 配置选项到服务器配置结构体
- 在日志初始化时支持可选的 Sentry 错误追踪
- 仅在错误级别日志上报到 Sentry
- 更新依赖以支持 Sentry 集成

此更改允许可配置的错误监控，提高应用的可观测性和问题诊断能力。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 引入了 Sentry 错误追踪与监控集成，用户现可通过新增配置选项启用 Sentry 并设置相关信息，从而使日志系统只捕获关键错误，提高错误监控的精准性。
  - 增加了对 `tracing` 的支持，以增强日志记录和追踪功能。 

- **错误修复**
  - 改进了服务器启动时的错误处理逻辑，确保在启动失败时记录错误信息并适当退出。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->