### PR TITLE
fix(parser): 增强剧集范围正则匹配，支持 Fin 后缀

### DIFF
--- a/crates/downloader/src/config.rs
+++ b/crates/downloader/src/config.rs
@@ -29,7 +29,7 @@ impl Default for Config {
             sync_interval: Duration::from_secs(10),
             event_queue_size: 128,
             max_retry_count: 5,
-            retry_processor_interval: Duration::from_secs(5),
+            retry_processor_interval: Duration::from_secs(30),
             retry_min_interval: chrono::Duration::seconds(30),
             retry_max_interval: chrono::Duration::minutes(10),
             download_dir: PathBuf::from("/"),

--- a/crates/downloader/src/lib.rs
+++ b/crates/downloader/src/lib.rs
@@ -24,6 +24,7 @@ pub trait Downloader: Send + Sync {
     async fn list_tasks(&self, info_hashes: &[String]) -> Result<Vec<Model>>;
     async fn download_file(&self, info_hash: &str, ua: &str) -> Result<DownloadInfo>;
     async fn cancel_task(&self, info_hash: &str) -> Result<()>;
+    async fn remove_task(&self, info_hash: &str, remove_files: bool) -> Result<()>;
     async fn metrics(&self) -> metrics::Metrics;
     async fn subscribe(&self) -> broadcast::Receiver<Event>;
     async fn retry(&self, info_hash: &str) -> Result<()>;

--- a/crates/downloader/src/worker.rs
+++ b/crates/downloader/src/worker.rs
@@ -555,6 +555,10 @@ impl Downloader for Worker {
     async fn retry(&self, info_hash: &str) -> Result<()> {
         self.retry_task(info_hash)
     }
+
+    async fn remove_task(&self, info_hash: &str, remove_files: bool) -> Result<()> {
+        self.downloader.remove_task(info_hash, remove_files).await
+    }
 }
 
 impl Worker {

--- a/crates/parser/src/worker.rs
+++ b/crates/parser/src/worker.rs
@@ -15,8 +15,10 @@ lazy_static! {
     // - 1-12
     // - E01-E12
     // - EP01-EP12
+    // - 01-12Fin
+    // - E01-E12Fin
     // 通过限制数字长度来避免匹配日期格式（如 2023-01）
-    static ref EPISODE_RANGE: Regex = Regex::new(r"(?i)(?:EP?\.?\s*)?([0-9]{1,2})-(?:EP?\.?\s*)?([0-9]{1,2})\b").unwrap();
+    static ref EPISODE_RANGE: Regex = Regex::new(r"(?i)(?:EP?\.?\s*)?([0-9]{1,2})-(?:EP?\.?\s*)?([0-9]{1,2})(?:\w+)?\b").unwrap();
 
     // 匹配年份-月份格式（如 2023-01）
     static ref DATE_PATTERN: Regex = Regex::new(r"\d{4}-(?:0[1-9]|1[0-2])").unwrap();
@@ -262,6 +264,7 @@ mod tests {
             "动漫国字幕组】★07月新番[异世界舅舅][01-13(全集)][720P][繁体][MP4]",
             "[喵萌奶茶屋&LoliHouse] 无职转生 01-11 合集 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]",
             "[桜都字幕组] 无职转生 01-23 [BDrip][1080P][HEVC_FLACx2]",
+            "[桜都字幕组] 想要成为影之实力者！ / Kage no Jitsuryokusha ni Naritakute! [01-20Fin][1080p][简体内嵌]"
         ];
 
         // 测试应该通过的文件名

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -176,7 +176,7 @@ impl Scheduler {
         // 如果任务存在，则取消之前的任务
         if let Some(old_task) = task {
             if let Some(ref_info_hash) = old_task.ref_torrent_info_hash {
-                self.downloader.cancel_task(&ref_info_hash).await?;
+                self.downloader.remove_task(&ref_info_hash, true).await?;
             }
         } else {
             // 插入新的剧集下载任务


### PR DESCRIPTION
close: #228

- 更新 EPISODE_RANGE 正则表达式，支持匹配带 Fin 后缀的剧集范围
- 添加测试用例，验证新的正则匹配规则
- 改进文件名解析的灵活性和准确性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增了异步任务移除功能，支持可选删除关联文件，提升任务管理的灵活性。
- **改进**
  - 修改了下载任务的重试间隔，默认从5秒延长至30秒，改善了任务重试流程。
  - 优化了剧集文件名匹配规则，现可识别带额外后缀的格式，提升了文件识别的准确性。
- **任务调度**
  - 更新了手动选择剧集操作逻辑，由仅取消任务改为彻底移除任务，简化了任务清理流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->