### PR TITLE
feat(downloader): 番剧订阅时，可以指定下载器

### DIFF
--- a/crates/downloader/src/lib.rs
+++ b/crates/downloader/src/lib.rs
@@ -25,7 +25,12 @@ use model::{
 
 #[async_trait]
 pub trait Downloader: Send + Sync {
-    async fn add_task(&self, resource: Resource, dir: PathBuf) -> Result<()>;
+    async fn add_task(
+        &self,
+        resource: Resource,
+        dir: PathBuf,
+        downloader: Option<String>,
+    ) -> Result<()>;
     async fn list_tasks(&self, info_hashes: &[String]) -> Result<Vec<Model>>;
     async fn list_files(&self, info_hash: &str) -> Result<Vec<FileInfo>>;
     async fn download_file(&self, file_id: &str, ua: &str) -> Result<DownloadInfo>;

--- a/crates/downloader/src/lib.rs
+++ b/crates/downloader/src/lib.rs
@@ -30,6 +30,7 @@ pub trait Downloader: Send + Sync {
         resource: Resource,
         dir: PathBuf,
         downloader: Option<String>,
+        allow_fallback: bool,
     ) -> Result<()>;
     async fn list_tasks(&self, info_hashes: &[String]) -> Result<Vec<Model>>;
     async fn list_files(&self, info_hash: &str) -> Result<Vec<FileInfo>>;
@@ -43,6 +44,7 @@ pub trait Downloader: Send + Sync {
     async fn resume_task(&self, info_hash: &str) -> Result<()>;
     fn supports_resource_type(&self, resource_type: ResourceType) -> bool;
     fn recommended_resource_type(&self) -> ResourceType;
+    fn get_downloader(&self, downloader: &str) -> Option<&dyn ThirdPartyDownloader>;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/downloader/src/lib.rs
+++ b/crates/downloader/src/lib.rs
@@ -23,6 +23,12 @@ use model::{
     torrents::Model as TorrentModel,
 };
 
+#[derive(Debug, Clone)]
+pub struct DownloaderInfo {
+    pub name: String,
+    pub priority: u8,
+}
+
 #[async_trait]
 pub trait Downloader: Send + Sync {
     async fn add_task(
@@ -45,6 +51,7 @@ pub trait Downloader: Send + Sync {
     fn supports_resource_type(&self, resource_type: ResourceType) -> bool;
     fn recommended_resource_type(&self) -> ResourceType;
     fn get_downloader(&self, downloader: &str) -> Option<&dyn ThirdPartyDownloader>;
+    fn list_downloaders(&self) -> Vec<DownloaderInfo>;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/downloader/src/worker.rs
+++ b/crates/downloader/src/worker.rs
@@ -281,8 +281,7 @@ impl Worker {
         allow_fallback: bool,
     ) -> Result<()> {
         let downloader = if let Some(downloader_name) = downloader {
-            self.get_downloader(&downloader_name)
-                .context(format!("指定的下载器不存在: {}", downloader_name))?
+            self.take_downloader(&downloader_name)?
         } else {
             self.best_downloader()
         };

--- a/crates/downloader/src/worker.rs
+++ b/crates/downloader/src/worker.rs
@@ -280,8 +280,9 @@ impl Worker {
         downloader: Option<String>,
         allow_fallback: bool,
     ) -> Result<()> {
-        let downloader = if let Some(downloader) = downloader {
-            self.take_downloader(&downloader)
+        let downloader = if let Some(downloader_name) = downloader {
+            self.get_downloader(&downloader_name)
+                .context(format!("指定的下载器不存在: {}", downloader_name))?
         } else {
             self.best_downloader()
         };
@@ -784,12 +785,12 @@ impl Worker {
             .clone()
     }
 
-    fn best_downloader(&self) -> Arc<Box<dyn ThirdPartyDownloader>> {
-        self.downloaders
+    fn best_downloader(&self) -> &dyn ThirdPartyDownloader {
+        &***self
+            .downloaders
             .iter()
             .max_by_key(|d| d.config().priority)
             .unwrap()
-            .clone()
     }
 
     async fn update_task_retry_status(

--- a/crates/downloader/src/worker.rs
+++ b/crates/downloader/src/worker.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     config::Config, db::Db, metrics, thirdparty::pan_115_impl::Pan115DownloaderImpl, Downloader,
-    Event, FileInfo, Resource, ResourceType, Store, ThirdPartyDownloader,
+    DownloaderInfo, Event, FileInfo, Resource, ResourceType, Store, ThirdPartyDownloader,
 };
 
 type State = DownloadStatus;
@@ -896,6 +896,21 @@ impl Downloader for Worker {
             .iter()
             .find(|d| d.name() == downloader)
             .map(|d| &***d)
+    }
+
+    fn list_downloaders(&self) -> Vec<DownloaderInfo> {
+        let mut downloaders: Vec<DownloaderInfo> = self
+            .downloaders
+            .iter()
+            .map(|d| DownloaderInfo {
+                name: d.name().to_string(),
+                priority: d.config().priority,
+            })
+            .collect();
+
+        downloaders.sort_by(|a, b| b.priority.cmp(&a.priority));
+
+        downloaders
     }
 }
 

--- a/crates/downloader/tests/test_worker.rs
+++ b/crates/downloader/tests/test_worker.rs
@@ -106,7 +106,7 @@ async fn test_retry_exceed_max_count() {
     let resource = create_test_resource();
     // 添加任务
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test"))
+        .add_task(resource.clone(), PathBuf::from("test"), None)
         .await
         .unwrap();
 
@@ -163,7 +163,7 @@ async fn test_download_timeout_no_retry() {
 
     // 添加任务
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test"))
+        .add_task(resource.clone(), PathBuf::from("test"), None)
         .await
         .unwrap();
 
@@ -235,7 +235,7 @@ async fn test_worker_retry_success() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"))
+        .add_task(resource.clone(), PathBuf::from("test2"), None)
         .await
         .unwrap();
 
@@ -284,7 +284,7 @@ async fn test_worker_add_task_success() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"))
+        .add_task(resource.clone(), PathBuf::from("test2"), None)
         .await
         .unwrap();
 
@@ -332,7 +332,7 @@ async fn test_worker_add_cancel_downloading_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"))
+        .add_task(resource.clone(), PathBuf::from("test2"), None)
         .await
         .unwrap();
 
@@ -397,7 +397,7 @@ async fn test_worker_add_retry_failed_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"))
+        .add_task(resource.clone(), PathBuf::from("test2"), None)
         .await
         .unwrap();
 
@@ -506,7 +506,7 @@ async fn test_worker_pause_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"))
+        .add_task(resource.clone(), PathBuf::from("test2"), None)
         .await
         .unwrap();
 
@@ -554,7 +554,7 @@ async fn test_worker_resume_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"))
+        .add_task(resource.clone(), PathBuf::from("test2"), None)
         .await
         .unwrap();
 
@@ -604,7 +604,7 @@ async fn test_worker_user_manual_pause_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"))
+        .add_task(resource.clone(), PathBuf::from("test2"), None)
         .await
         .unwrap();
 
@@ -706,7 +706,7 @@ async fn test_worker_fallback_task() {
     // 添加下载任务
     let resource = create_test_resource();
     worker
-        .add_task(resource.clone(), PathBuf::from("/tmp"))
+        .add_task(resource.clone(), PathBuf::from("/tmp"), None)
         .await
         .unwrap();
 

--- a/crates/downloader/tests/test_worker.rs
+++ b/crates/downloader/tests/test_worker.rs
@@ -106,7 +106,7 @@ async fn test_retry_exceed_max_count() {
     let resource = create_test_resource();
     // 添加任务
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test"), None)
+        .add_task(resource.clone(), PathBuf::from("test"), None, true)
         .await
         .unwrap();
 
@@ -163,7 +163,7 @@ async fn test_download_timeout_no_retry() {
 
     // 添加任务
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test"), None)
+        .add_task(resource.clone(), PathBuf::from("test"), None, true)
         .await
         .unwrap();
 
@@ -235,7 +235,7 @@ async fn test_worker_retry_success() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"), None)
+        .add_task(resource.clone(), PathBuf::from("test2"), None, true)
         .await
         .unwrap();
 
@@ -284,7 +284,7 @@ async fn test_worker_add_task_success() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"), None)
+        .add_task(resource.clone(), PathBuf::from("test2"), None, true)
         .await
         .unwrap();
 
@@ -332,7 +332,7 @@ async fn test_worker_add_cancel_downloading_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"), None)
+        .add_task(resource.clone(), PathBuf::from("test2"), None, true)
         .await
         .unwrap();
 
@@ -397,7 +397,7 @@ async fn test_worker_add_retry_failed_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"), None)
+        .add_task(resource.clone(), PathBuf::from("test2"), None, true)
         .await
         .unwrap();
 
@@ -449,6 +449,7 @@ async fn test_worker_recover_pending_tasks() {
             updated_at: Local::now().naive_utc(),
             magnet: None,
             resource_type: resource.get_type(),
+            allow_fallback: true,
         })
         .await
         .unwrap();
@@ -506,7 +507,7 @@ async fn test_worker_pause_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"), None)
+        .add_task(resource.clone(), PathBuf::from("test2"), None, true)
         .await
         .unwrap();
 
@@ -554,7 +555,7 @@ async fn test_worker_resume_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"), None)
+        .add_task(resource.clone(), PathBuf::from("test2"), None, true)
         .await
         .unwrap();
 
@@ -604,7 +605,7 @@ async fn test_worker_user_manual_pause_task() {
 
     // 添加任务并同步
     worker_clone
-        .add_task(resource.clone(), PathBuf::from("test2"), None)
+        .add_task(resource.clone(), PathBuf::from("test2"), None, true)
         .await
         .unwrap();
 
@@ -706,7 +707,7 @@ async fn test_worker_fallback_task() {
     // 添加下载任务
     let resource = create_test_resource();
     worker
-        .add_task(resource.clone(), PathBuf::from("/tmp"), None)
+        .add_task(resource.clone(), PathBuf::from("/tmp"), None, true)
         .await
         .unwrap();
 
@@ -725,6 +726,111 @@ async fn test_worker_fallback_task() {
     assert_eq!(task.resource_type, resource.get_type());
     assert_eq!(task.magnet, resource.magnet());
     assert_eq!(task.downloader, "failed,success");
+
+    // 关闭工作者
+    worker.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_worker_fallback_task_with_allow_fallback_false() {
+    // 初始化测试环境
+    init_test_env();
+
+    // 创建两个下载器，一个会失败，一个会成功
+    let mut failed_config = create_test_config();
+    failed_config.priority = 2; // 优先级更高，会先使用
+    failed_config.max_retry_count = 0; // 失败后直接切换到备用下载器
+    let mut failed_downloader = MockThirdPartyDownloader::new();
+    failed_downloader
+        .expect_add_task()
+        .returning(|_, _| Err(anyhow::anyhow!("模拟下载失败")));
+    failed_downloader.expect_name().returning(|| "failed");
+    failed_downloader.expect_list_tasks().returning(|_| {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "f6ebf8a1f26d01f317c8e94ec40ebb3dd1a75d40".to_string(),
+            RemoteTaskStatus {
+                status: DownloadStatus::Failed,
+                err_msg: Some("模拟下载失败".to_string()),
+                result: None,
+            },
+        );
+        Ok(tasks)
+    });
+    failed_downloader
+        .expect_config()
+        .return_const(failed_config);
+    failed_downloader
+        .expect_remove_task()
+        .returning(|_, _| Ok(()));
+
+    let mut success_config = create_test_config();
+    success_config.priority = 1;
+    success_config.max_retry_count = 0;
+    let mut success_downloader = MockThirdPartyDownloader::new();
+    success_downloader
+        .expect_add_task()
+        .returning(|_, _| Ok(Some("success".to_string())));
+    success_downloader.expect_name().returning(|| "success");
+    success_downloader.expect_list_tasks().returning(|_| {
+        let mut tasks = HashMap::new();
+        tasks.insert(
+            "f6ebf8a1f26d01f317c8e94ec40ebb3dd1a75d40".to_string(),
+            RemoteTaskStatus {
+                status: DownloadStatus::Downloading,
+                err_msg: None,
+                result: None,
+            },
+        );
+        Ok(tasks)
+    });
+    success_downloader
+        .expect_remove_task()
+        .returning(|_, _| Ok(()));
+    success_downloader
+        .expect_config()
+        .return_const(success_config);
+
+    // 创建存储和配置
+    let store = MockStore::new();
+    let config = Config {
+        event_queue_size: 100,
+        sync_interval: Duration::from_secs(1),
+        retry_processor_interval: Duration::from_secs(1),
+    };
+
+    // 创建下载器工作者
+    let mut worker = Worker::new_with_conn(
+        Box::new(store.clone()),
+        config,
+        vec![
+            Arc::new(Box::new(failed_downloader)),
+            Arc::new(Box::new(success_downloader)),
+        ],
+    )
+    .unwrap();
+
+    // 启动工作者
+    worker.spawn().await.unwrap();
+
+    // 添加下载任务
+    let resource = create_test_resource();
+    worker
+        .add_task(resource.clone(), PathBuf::from("/tmp"), None, false)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    worker.sync_remote_task_status().await;
+    // 验证最终使用的下载器
+    let tasks = store.get_tasks().await;
+    assert_eq!(tasks.len(), 1);
+    let task = &tasks[0];
+    assert_eq!(task.retry_count, 0, "切换下载器后重试次数应该重置");
+    assert_eq!(task.download_status, DownloadStatus::Failed);
+    assert_eq!(task.resource_type, resource.get_type());
+    assert_eq!(task.magnet, resource.magnet());
+    assert_eq!(task.downloader, "failed");
 
     // 关闭工作者
     worker.shutdown().await.unwrap();

--- a/crates/model/src/entity/subscriptions.rs
+++ b/crates/model/src/entity/subscriptions.rs
@@ -19,6 +19,8 @@ pub struct Model {
     pub collector_interval: Option<i32>,
     pub metadata_interval: Option<i32>,
     pub enforce_torrent_release_after_broadcast: i8,
+    pub preferred_downloader: Option<String>,
+    pub allow_fallback: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/model/src/entity/torrent_download_tasks.rs
+++ b/crates/model/src/entity/torrent_download_tasks.rs
@@ -12,6 +12,7 @@ pub struct Model {
     pub info_hash: String,
     pub download_status: DownloadStatus,
     pub downloader: String,
+    pub allow_fallback: bool,
     pub dir: String,
     #[sea_orm(column_type = "Text", nullable)]
     pub context: Option<String>,

--- a/crates/scheduler/src/db.rs
+++ b/crates/scheduler/src/db.rs
@@ -389,6 +389,8 @@ impl Db {
         collector_interval: Option<i32>,
         metadata_interval: Option<i32>,
         enforce_torrent_release_after_broadcast: bool,
+        preferred_downloader: Option<String>,
+        allow_fallback: bool,
     ) -> Result<()> {
         use model::subscriptions::Column as SubscriptionColumn;
         use model::subscriptions::Entity as Subscriptions;
@@ -405,6 +407,8 @@ impl Db {
             enforce_torrent_release_after_broadcast: Set(
                 enforce_torrent_release_after_broadcast as i8
             ),
+            preferred_downloader: Set(preferred_downloader),
+            allow_fallback: Set(allow_fallback),
             ..Default::default()
         };
 
@@ -420,6 +424,8 @@ impl Db {
                     .update_column(SubscriptionColumn::MetadataInterval)
                     .update_column(SubscriptionColumn::StartEpisodeNumber)
                     .update_column(SubscriptionColumn::EnforceTorrentReleaseAfterBroadcast)
+                    .update_column(SubscriptionColumn::PreferredDownloader)
+                    .update_column(SubscriptionColumn::AllowFallback)
                     .to_owned(),
             )
             .exec(self.conn())

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -183,20 +183,12 @@ impl Scheduler {
             .await?
             .context("你需要先订阅番剧")?;
 
-        let mut using_torrent = false;
-        if let Some(ref preferred_downloader) = subscribe.preferred_downloader {
-            if let Some(downloader) = self.downloader.get_downloader(preferred_downloader) {
-                using_torrent = downloader.recommended_resource_type() == ResourceType::Torrent
-                    && torrent.data.is_some();
-            }
-        } else {
-            using_torrent = self.downloader.recommended_resource_type() == ResourceType::Torrent
-                && torrent.data.is_some();
-        }
-
         // 如果推荐资源类型为种子，则尝试下载种子
         #[allow(clippy::collapsible_if)]
-        if using_torrent {
+        if self
+            .task_manager
+            .use_torrent_to_download(&subscribe, &torrent)
+        {
             if torrent.data.is_none() && torrent.download_url.is_some() {
                 match download_torrent(&self.client, &torrent.download_url.unwrap()).await {
                     Ok(data) => {

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use downloader::Downloader;
-use model::sea_orm_active_enums::ResourceType;
 use model::subscriptions;
 use sea_orm::DatabaseConnection;
 use std::{collections::HashMap, sync::Arc};

--- a/crates/scheduler/src/subscribe.rs
+++ b/crates/scheduler/src/subscribe.rs
@@ -15,6 +15,8 @@ impl Scheduler {
         collector_interval: Option<i32>,
         metadata_interval: Option<i32>,
         enforce_torrent_release_after_broadcast: bool,
+        preferred_downloader: Option<String>,
+        allow_fallback: bool,
     ) -> Result<()> {
         // 将分辨率列表转换为逗号分隔的字符串
         let resolution_filter_str = resolution_filter.map(|resolutions| {
@@ -80,6 +82,8 @@ impl Scheduler {
                 collector_interval,
                 metadata_interval,
                 enforce_torrent_release_after_broadcast,
+                preferred_downloader,
+                allow_fallback,
             )
             .await
             .context("更新订阅状态失败")?;

--- a/crates/scheduler/src/tasks.rs
+++ b/crates/scheduler/src/tasks.rs
@@ -247,6 +247,7 @@ impl TaskManager {
                             .add_task(
                                 Resource::from_torrent_file_bytes(torrent.data.unwrap())?,
                                 PathBuf::from(bangumi.name),
+                                None,
                             )
                             .await?;
                     } else {
@@ -254,6 +255,7 @@ impl TaskManager {
                             .add_task(
                                 Resource::from_info_hash(torrent.info_hash)?,
                                 PathBuf::from(bangumi.name),
+                                None,
                             )
                             .await?;
                     }

--- a/crates/scheduler/src/tasks.rs
+++ b/crates/scheduler/src/tasks.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use downloader::{resource::Resource, Downloader, Event};
 use model::sea_orm_active_enums::{ResourceType, State};
 use model::{episode_download_tasks, sea_orm_active_enums::DownloadStatus};
+use model::{subscriptions, torrents};
 use sea_orm::Set;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -162,6 +163,31 @@ impl TaskManager {
         self.db.batch_create_tasks(tasks).await?;
         Ok(())
     }
+
+    pub fn use_torrent_to_download(
+        &self,
+        subscribe: &subscriptions::Model,
+        torrent: &torrents::Model,
+    ) -> bool {
+        let mut using_torrent = false;
+        let mut use_preferred_downloader = false;
+        // 如果指定了下载器，则使用指定的下载器
+        if let Some(ref preferred_downloader) = subscribe.preferred_downloader {
+            if let Some(downloader) = self.downloader.get_downloader(preferred_downloader) {
+                using_torrent = downloader.recommended_resource_type() == ResourceType::Torrent
+                    && torrent.data.is_some();
+                use_preferred_downloader = true;
+            } else {
+                warn!("指定的下载器 {} 不存在", preferred_downloader);
+            }
+        }
+        if !use_preferred_downloader {
+            // 如果没有指定下载器，则使用默认的下载器
+            using_torrent = self.downloader.recommended_resource_type() == ResourceType::Torrent
+                && torrent.data.is_some();
+        }
+        using_torrent
+    }
 }
 
 impl TaskManager {
@@ -243,23 +269,9 @@ impl TaskManager {
                         .get_subscription(task.bangumi_id)
                         .await?
                         .context("你需要先订阅番剧")?;
-                    let mut using_torrent = false;
-                    if let Some(ref preferred_downloader) = subscribe.preferred_downloader {
-                        if let Some(downloader) =
-                            self.downloader.get_downloader(preferred_downloader)
-                        {
-                            using_torrent = downloader.recommended_resource_type()
-                                == ResourceType::Torrent
-                                && torrent.data.is_some();
-                        }
-                    } else {
-                        using_torrent = self.downloader.recommended_resource_type()
-                            == ResourceType::Torrent
-                            && torrent.data.is_some();
-                    }
 
                     // 创建下载任务, 如果推荐资源类型为种子，则优先提供种子
-                    if using_torrent {
+                    if self.use_torrent_to_download(&subscribe, &torrent) {
                         self.downloader
                             .add_task(
                                 Resource::from_torrent_file_bytes(torrent.data.unwrap())?,

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -859,6 +859,8 @@ pub async fn list_bangumi(
         .column(SubscriptionColumn::LanguageFilter)
         .column(SubscriptionColumn::ReleaseGroupFilter)
         .column(SubscriptionColumn::EnforceTorrentReleaseAfterBroadcast)
+        .column(SubscriptionColumn::PreferredDownloader)
+        .column(SubscriptionColumn::AllowFallback)
         // 联表查询
         .join_rev(
             JoinType::LeftJoin,

--- a/crates/server/src/model.rs
+++ b/crates/server/src/model.rs
@@ -62,6 +62,8 @@ pub struct Bangumi {
     pub release_group_filter: Option<String>,
     #[sea_orm(column_type = "Boolean")]
     pub enforce_torrent_release_after_broadcast: Option<bool>,
+    pub preferred_downloader: Option<String>,
+    pub allow_fallback: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, FromQueryResult)]
@@ -118,6 +120,9 @@ pub struct SubscribeParams {
     pub metadata_interval: Option<i32>,
     #[serde(default)]
     pub enforce_torrent_release_after_broadcast: bool,
+    pub preferred_downloader: Option<String>,
+    #[serde(default)]
+    pub allow_fallback: bool,
 }
 
 // 定义一个结构体来接收查询结果
@@ -245,4 +250,10 @@ pub struct DownloadedFile {
     pub file_name: String,
     pub file_size: usize,
     pub file_type: FileType,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DownloaderInfo {
+    pub name: String,
+    pub priority: u8,
 }

--- a/crates/server/src/model.rs
+++ b/crates/server/src/model.rs
@@ -63,7 +63,7 @@ pub struct Bangumi {
     #[sea_orm(column_type = "Boolean")]
     pub enforce_torrent_release_after_broadcast: Option<bool>,
     pub preferred_downloader: Option<String>,
-    pub allow_fallback: bool,
+    pub allow_fallback: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, FromQueryResult)]

--- a/crates/server/src/router.rs
+++ b/crates/server/src/router.rs
@@ -37,5 +37,6 @@ pub fn configure_app(cfg: &mut web::ServiceConfig, state: Arc<AppState>) {
         .service(api::add_bangumi)
         .service(api::get_version)
         .service(api::list_download_files)
+        .service(api::list_downloaders)
         .route("/ws", web::get().to(ws_handler));
 }

--- a/develop/migrations/V1.1.0__sub_option.sql
+++ b/develop/migrations/V1.1.0__sub_option.sql
@@ -1,0 +1,8 @@
+alter table subscriptions
+    add preferred_downloader varchar(255) null;
+
+alter table subscriptions
+    add allow_fallback bool default true not null;
+
+alter table torrent_download_tasks
+    add allow_fallback bool default true not null;

--- a/web/src/api/api.ts
+++ b/web/src/api/api.ts
@@ -17,7 +17,8 @@ import type {
   QueryBangumiParams,
   MikanSearchResultItem,
   AddBangumiParams,
-  DownloadedFile
+  DownloadedFile,
+  DownloaderInfo
 } from './model'
 import { ApiError } from './model'
 import { useSnackbar } from '../composables/useSnackbar'
@@ -276,5 +277,14 @@ export async function addBangumi(params: AddBangumiParams): Promise<number> {
     return handleResponse(response, '添加番剧失败')
   } catch (error) {
     return handleError(error, '添加番剧失败')
+  }
+}
+
+export async function listDownloaders(): Promise<DownloaderInfo[]> {
+  try {
+    const response = await api.get<ApiResponse<DownloaderInfo[]>>('/downloaders')
+    return handleResponse(response, '获取下载器列表失败')
+  } catch (error) {
+    return handleError(error, '获取下载器列表失败')
   }
 }

--- a/web/src/api/model.ts
+++ b/web/src/api/model.ts
@@ -61,6 +61,8 @@ export interface SubscribeParams {
   collector_interval?: number | undefined
   metadata_interval?: number | undefined
   enforce_torrent_release_after_broadcast?: boolean | undefined
+  preferred_downloader?: string | undefined
+  allow_fallback?: boolean | undefined
 }
 
 // 番剧信息
@@ -86,6 +88,8 @@ export interface Bangumi {
   language_filter: string | null
   release_group_filter: string | null
   enforce_torrent_release_after_broadcast: boolean | null
+  preferred_downloader: string | null
+  allow_fallback: boolean
 }
 
 // 剧集信息
@@ -412,4 +416,9 @@ export interface DownloadedFile {
   file_name: string
   file_size: number
   file_type: string
+}
+
+export interface DownloaderInfo {
+  name: string
+  priority: number
 }

--- a/web/src/components/MediaCard.vue
+++ b/web/src/components/MediaCard.vue
@@ -163,7 +163,9 @@ const currentSubscribeSettings = computed(() => {
     language_filter: props.item.language_filter ?? undefined,
     release_group_filter: props.item.release_group_filter ?? undefined,
     status: props.item.subscribe_status ?? undefined,
-    enforce_torrent_release_after_broadcast: props.item.enforce_torrent_release_after_broadcast ?? undefined
+    enforce_torrent_release_after_broadcast: props.item.enforce_torrent_release_after_broadcast ?? undefined,
+    preferred_downloader: props.item.preferred_downloader ?? undefined,
+    allow_fallback: props.item.allow_fallback ?? true
   }
 })
 

--- a/web/src/pages/detail.vue
+++ b/web/src/pages/detail.vue
@@ -2012,7 +2012,9 @@ const currentSubscribeSettings = computed(() => {
     language_filter: anime.value.language_filter ?? undefined,
     release_group_filter: anime.value.release_group_filter ?? undefined,
     status: anime.value.subscribe_status ?? undefined,
-    enforce_torrent_release_after_broadcast: anime.value.enforce_torrent_release_after_broadcast ?? undefined
+    enforce_torrent_release_after_broadcast: anime.value.enforce_torrent_release_after_broadcast ?? undefined,
+    preferred_downloader: anime.value.preferred_downloader ?? undefined,
+    allow_fallback: anime.value.allow_fallback ?? true
   }
 })
 


### PR DESCRIPTION
close: #265

**TODO:** 
还需要处理以下情况: 下载任务关联了某个下载器，然后下载器没有被启用，此时需要设置为失败状态，然后直接fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 订阅设置现支持选择首选下载器和配置是否允许自动降级，提升下载任务管理的灵活性。
  - 新增API接口可展示可用下载器列表，展示下载器名称及优先级，便于用户参考。
  - 用户界面更新：订阅对话框、媒体卡等页面新增了下载器选择列表和降级控制开关，改善用户体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->