### PR TITLE
feat: 下载器支持直接传入种子下载链接

### DIFF
--- a/crates/downloader/src/db.rs
+++ b/crates/downloader/src/db.rs
@@ -39,7 +39,12 @@ impl Db {
         )
         .on_conflict(
             OnConflict::column(Column::InfoHash)
-                .update_columns([Column::UpdatedAt])
+                .update_columns([
+                    Column::UpdatedAt,
+                    Column::DownloadStatus,
+                    Column::TorrentUrl,
+                    Column::ErrMsg,
+                ])
                 .to_owned(),
         )
         .exec(&*self.conn)

--- a/crates/downloader/src/thirdparty/qbittorrent_impl.rs
+++ b/crates/downloader/src/thirdparty/qbittorrent_impl.rs
@@ -94,6 +94,12 @@ impl ThirdPartyDownloader for QbittorrentDownloaderImpl {
                     torrents: vec![torrent],
                 }
             }
+            Resource::TorrentURL(url, _info_hash) => {
+                let url = url.parse::<Url>()?;
+                TorrentSource::Urls {
+                    urls: Sep::from(vec![url]),
+                }
+            }
         };
         let arg = AddTorrentArg {
             source,
@@ -227,12 +233,15 @@ impl ThirdPartyDownloader for QbittorrentDownloaderImpl {
     fn supports_resource_type(&self, resource_type: ResourceType) -> bool {
         matches!(
             resource_type,
-            ResourceType::Magnet | ResourceType::InfoHash | ResourceType::Torrent
+            ResourceType::Magnet
+                | ResourceType::InfoHash
+                | ResourceType::Torrent
+                | ResourceType::TorrentURL
         )
     }
 
     fn recommended_resource_type(&self) -> ResourceType {
-        ResourceType::Torrent
+        ResourceType::TorrentURL
     }
 
     fn config(&self) -> &config::GenericConfig {

--- a/crates/downloader/src/worker.rs
+++ b/crates/downloader/src/worker.rs
@@ -165,6 +165,12 @@ impl Worker {
                 Resource::from_magnet_link(magnet)?
             }
             ResourceType::InfoHash => Resource::from_info_hash(task.info_hash.clone())?,
+            ResourceType::TorrentURL => {
+                let torrent_url = task.torrent_url.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("种子下载URL为空: info_hash={}", task.info_hash)
+                })?;
+                Resource::from_torrent_url(torrent_url, &task.info_hash)?
+            }
         })
     }
 
@@ -300,6 +306,7 @@ impl Worker {
             next_retry_at: now,
             resource_type: resource.get_type(),
             magnet: resource.magnet(),
+            torrent_url: resource.torrent_url(),
         };
 
         self.store.upsert(task).await?;

--- a/crates/downloader/tests/test_worker.rs
+++ b/crates/downloader/tests/test_worker.rs
@@ -450,6 +450,7 @@ async fn test_worker_recover_pending_tasks() {
             magnet: None,
             resource_type: resource.get_type(),
             allow_fallback: true,
+            torrent_url: None,
         })
         .await
         .unwrap();

--- a/crates/model/src/entity/sea_orm_active_enums.rs
+++ b/crates/model/src/entity/sea_orm_active_enums.rs
@@ -60,6 +60,8 @@ pub enum ParserStatus {
 pub enum ResourceType {
     #[sea_orm(string_value = "torrent")]
     Torrent,
+    #[sea_orm(string_value = "torrent_url")]
+    TorrentURL,
     #[sea_orm(string_value = "magnet")]
     Magnet,
     #[sea_orm(string_value = "info_hash")]

--- a/crates/model/src/entity/torrent_download_tasks.rs
+++ b/crates/model/src/entity/torrent_download_tasks.rs
@@ -25,6 +25,8 @@ pub struct Model {
     pub resource_type: ResourceType,
     #[sea_orm(column_type = "Text", nullable)]
     pub magnet: Option<String>,
+    #[sea_orm(column_type = "Text", nullable)]
+    pub torrent_url: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/develop/migrations/V1.1.1__resource.sql
+++ b/develop/migrations/V1.1.1__resource.sql
@@ -1,0 +1,5 @@
+alter table torrent_download_tasks
+    modify resource_type enum ('torrent', 'torrent_url', 'magnet', 'info_hash') default 'info_hash' not null;
+    
+alter table torrent_download_tasks
+    add torrent_url text null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 现已支持通过 Torrent URL 与对应 info hash 创建下载任务，用户可以直接使用 Torrent URL 进行下载。
  - 下载器与任务管理器扩展了资源类型处理，推荐资源类型现调整为 Torrent URL。
  - 数据库架构更新，新增 Torrent URL 字段并扩展了可选资源类型。

- **Refactor**
  - 优化了任务调度与选择逻辑，提升下载流程的灵活性和错误反馈效果。

- **Tests**
  - 更新了测试用例，覆盖了 Torrent URL 场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->