### PR TITLE
feat: 增加no proxy 设置

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -13,6 +13,10 @@ level = "debug" # debug, info, warn, error
 enabled = false
 http = "http://127.0.0.1:7890"
 https = "http://127.0.0.1:7890"
+no_proxy = [
+    "localhost",
+    "127.0.0.1",
+]
 
 # TMDB API 配置
 [tmdb]

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -46,6 +46,7 @@ pub struct ProxyConfig {
     pub enabled: bool,
     pub http: String,
     pub https: String,
+    pub no_proxy: Vec<String>,
 }
 
 impl Default for ProxyConfig {
@@ -54,6 +55,7 @@ impl Default for ProxyConfig {
             enabled: false,
             http: "http://127.0.0.1:7890".to_owned(),
             https: "http://127.0.0.1:7890".to_owned(),
+            no_proxy: vec![],
         }
     }
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -88,9 +88,11 @@ impl Server {
 
         // HTTP Client
         let client = if config.proxy.enabled {
+            let no_proxy_list = config.proxy.no_proxy.join(",");
+            let no_proxy = reqwest::NoProxy::from_string(no_proxy_list.as_str());
             reqwest::Client::builder()
-                .proxy(reqwest::Proxy::http(&config.proxy.http)?)
-                .proxy(reqwest::Proxy::https(&config.proxy.https)?)
+                .proxy(reqwest::Proxy::http(&config.proxy.http)?.no_proxy(no_proxy.clone()))
+                .proxy(reqwest::Proxy::https(&config.proxy.https)?.no_proxy(no_proxy))
                 .build()?
         } else {
             reqwest::Client::new()

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -32,6 +32,12 @@ level = "info" # debug, info, warn, error
 enabled = false
 http = "http://127.0.0.1:7890"
 https = "http://127.0.0.1:7890"
+no_proxy = [
+    "localhost",
+    "127.0.0.1",
+    "qbittorrent",
+    "transmission",
+]
 
 # TMDB API 配置
 [tmdb]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了无代理（no_proxy）配置选项，允许用户设置多个地址（如 localhost、127.0.0.1 等）绕过代理，提高网络配置的灵活性。
	- 优化了代理设置，使得 HTTP 客户端能根据该选项自动跳过指定地址。

- **文档**
	- 更新了部署文档，详细说明了无代理配置选项的用法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->