### PR TITLE
fix: 修复 sentry 依赖

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3953,9 +3953,11 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
 dependencies = [
+ "httpdate",
  "reqwest",
  "rustls",
  "sentry-core",
+ "tokio",
  "ureq",
  "webpki-roots",
 ]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -48,7 +48,7 @@ dict = { path = "../dict" }
 sysinfo = { workspace = true }
 humantime-serde = { workspace = true }
 sentry-tracing = { workspace = true }
-sentry = { workspace = true, features = ["rustls"],default-features = false }
+sentry = { workspace = true, features = ["rustls", "reqwest"],default-features = false }
 [dev-dependencies]
 dotenv = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
```shell
backend-1  | === 程序发生严重错误 ===
backend-1  | 线程 'main' 在 /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/sentry-0.36.0/src/transports/mod.rs:120 发生panic: sentry crate was compiled without transport
backend-1  | 调用栈:
backend-1  | disabled backtrace
backend-1  | 程序因严重错误终止运行
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **杂项**
  - 调整了错误监控工具的依赖配置，新增了对网络请求的支持，进一步提升了整体集成的稳定性和兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->