### PR TITLE
refactor(alist): 重构Alist lib

### DIFF
--- a/libs/alist/src/auth.rs
+++ b/libs/alist/src/auth.rs
@@ -5,79 +5,20 @@ use crate::client::AListClient;
 use crate::Result;
 
 impl AListClient {
-    /// 登录AList获取Token
-    ///
-    /// 发送用户凭证到AList服务器，获取认证token。
-    ///
-    /// # 参数
-    ///
-    /// * `username` - 用户名
-    /// * `password` - 密码
-    /// * `otp_code` - 可选的二次验证码
-    ///
-    /// # 返回
-    ///
-    /// 成功时返回包含token的响应
-    ///
-    /// # 示例
-    ///
-    /// ```rust,no_run
-    /// # use alist::{AListClient, LoginRequest};
-    /// # use anyhow::Result;
-    /// #
-    /// # async fn example() -> Result<()> {
-    /// let client = AListClient::new("https://alist.example.com", "");
-    ///
-    /// // 无二次验证登录
-    /// let login_result = client.login("admin", "password123", None).await?;
-    /// println!("Token: {}", login_result.data.token);
-    ///
-    /// // 带二次验证登录
-    /// let login_result = client.login("admin", "password123", Some("123456")).await?;
-    /// println!("Token: {}", login_result.data.token);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn login(
-        &self,
-        username: impl Into<String>,
-        password: impl Into<String>,
-        otp_code: Option<impl Into<String>>,
-    ) -> Result<LoginResponse> {
+    pub async fn login(&mut self) -> Result<()> {
         let url = format!("{}/api/auth/login", self.base_url.trim_end_matches('/'));
 
         let request = LoginRequest {
-            username: username.into(),
-            password: password.into(),
-            otp_code: otp_code.map(|code| code.into()),
+            username: self.user_name.clone(),
+            password: self.user_password.clone(),
+            otp_code: None,
         };
 
-        self.post_json(&url, &request).await
+        let login_result: LoginResponse = self.post_json(&url, &request).await?;
+        self.token = login_result.token;
+        Ok(())
     }
 
-    /// 获取当前用户信息
-    ///
-    /// 使用已有的token获取当前登录用户的详细信息。
-    ///
-    /// # 返回
-    ///
-    /// 成功时返回包含用户信息的响应
-    ///
-    /// # 示例
-    ///
-    /// ```rust,no_run
-    /// # use alist::AListClient;
-    /// # use anyhow::Result;
-    /// #
-    /// # async fn example() -> Result<()> {
-    /// let client = AListClient::new("https://alist.example.com", "your_token_here");
-    ///
-    /// let user_info = client.get_me().await?;
-    /// println!("用户名: {}", user_info.data.username);
-    /// println!("角色: {}", user_info.data.role);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[instrument(skip(self), err)]
     pub async fn get_me(&self) -> Result<UserInfo> {
         let url = format!("{}/api/me", self.base_url.trim_end_matches('/'));

--- a/libs/alist/src/fs.rs
+++ b/libs/alist/src/fs.rs
@@ -8,40 +8,6 @@ use std::fmt::Debug;
 use tracing::{debug, info, instrument};
 
 impl AListClient {
-    /// 获取文件列表
-    ///
-    /// 根据给定路径获取文件和目录列表。
-    ///
-    /// # 参数
-    ///
-    /// * `path` - 要获取列表的目录路径
-    /// * `password` - 可选的文件夹密码
-    /// * `page` - 分页页码，从1开始
-    /// * `per_page` - 每页数量
-    /// * `refresh` - 是否刷新缓存
-    ///
-    /// # 返回
-    ///
-    /// 成功时返回包含文件列表的响应
-    ///
-    /// # 示例
-    ///
-    /// ```rust,no_run
-    /// # use alist::AListClient;
-    /// # use anyhow::Result;
-    /// #
-    /// # async fn example() -> Result<()> {
-    /// let client = AListClient::new("https://alist.example.com", "your_token_here");
-    ///
-    /// // 获取根目录文件列表
-    /// let files = client.list_files("/", None, 1, 100, false).await?;
-    /// for file in &files.content {
-    ///     println!("文件名: {}, 大小: {}, 是否文件夹: {}",
-    ///         file.name, file.size, file.is_dir);
-    /// }
-    /// # Ok(())
-    /// # }
-    /// ```
     #[instrument(skip(self, path, password), err)]
     pub async fn list_files(
         &self,
@@ -64,38 +30,6 @@ impl AListClient {
         self.post_json(&url, &request).await
     }
 
-    /// 获取目录下所有文件（递归遍历所有页）
-    ///
-    /// 获取指定路径下的所有文件，通过多次分页请求获取全部内容。
-    ///
-    /// # 参数
-    ///
-    /// * `path` - 要获取列表的目录路径
-    /// * `password` - 可选的文件夹密码
-    /// * `refresh` - 是否刷新缓存
-    ///
-    /// # 返回
-    ///
-    /// 成功时返回包含所有文件列表的响应
-    ///
-    /// # 示例
-    ///
-    /// ```rust,no_run
-    /// # use alist::AListClient;
-    /// # use anyhow::Result;
-    /// #
-    /// # async fn example() -> Result<()> {
-    /// let client = AListClient::new("https://alist.example.com", "your_token_here");
-    ///
-    /// // 获取根目录下所有文件
-    /// let all_files = client.list_all_files("/", None, false).await?;
-    /// println!("总文件数: {}, 总大小: {}", all_files.total_count, all_files.total_size);
-    /// for file in &all_files.files {
-    ///     println!("文件名: {}, 大小: {}", file.name, file.size);
-    /// }
-    /// # Ok(())
-    /// # }
-    /// ```
     #[instrument(skip(self, path, password), err)]
     pub async fn list_all_files(
         &self,
@@ -147,34 +81,6 @@ impl AListClient {
         })
     }
 
-    /// 获取文件下载链接
-    ///
-    /// 获取指定文件的下载链接。
-    ///
-    /// # 参数
-    ///
-    /// * `path` - 文件路径
-    /// * `password` - 可选的文件夹密码
-    ///
-    /// # 返回
-    ///
-    /// 成功时返回包含下载URL的响应
-    ///
-    /// # 示例
-    ///
-    /// ```rust,no_run
-    /// # use alist::AListClient;
-    /// # use anyhow::Result;
-    /// #
-    /// # async fn example() -> Result<()> {
-    /// let client = AListClient::new("https://alist.example.com", "your_token_here");
-    ///
-    /// // 获取文件下载链接
-    /// let file = client.get_file("/path/to/file.mp4", None).await?;
-    /// println!("下载URL: {}", file.raw_url);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[instrument(skip(self, path, password), err)]
     pub async fn get_file(
         &self,
@@ -191,47 +97,6 @@ impl AListClient {
         self.post_json(&url, &request).await
     }
 
-    /// 递归获取目录下所有文件
-    ///
-    /// 递归遍历指定路径及其所有子目录，获取所有文件。
-    ///
-    /// # 参数
-    ///
-    /// * `path` - 要遍历的目录路径
-    /// * `password` - 可选的文件夹密码
-    /// * `refresh` - 是否刷新缓存
-    /// * `max_depth` - 最大递归深度，None表示无限制
-    ///
-    /// # 返回
-    ///
-    /// 成功时返回包含所有文件的递归结果
-    ///
-    /// # 示例
-    ///
-    /// ```rust,no_run
-    /// # use alist::AListClient;
-    /// # use anyhow::Result;
-    /// #
-    /// # async fn example() -> Result<()> {
-    /// let client = AListClient::new("https://alist.example.com", "your_token_here");
-    ///
-    /// // 递归获取根目录下所有文件
-    /// let all_files = client.list_recursive_files("/", None, false, Some(3)).await?;
-    /// println!("总文件数: {}, 文件夹数: {}, 总大小: {}",
-    ///     all_files.total_count, all_files.total_dirs, all_files.total_size);
-    ///
-    /// // 输出所有文件夹
-    /// for dir in &all_files.directories {
-    ///     println!("文件夹: {}", dir);
-    /// }
-    ///
-    /// // 输出所有文件
-    /// for file in &all_files.files {
-    ///     println!("文件: {}, 大小: {}", file.name, file.size);
-    /// }
-    /// # Ok(())
-    /// # }
-    /// ```
     #[instrument(skip(self, path, password), err)]
     pub async fn list_recursive_files(
         &self,
@@ -355,13 +220,9 @@ mod tests {
             .with_max_level(tracing::Level::DEBUG)
             .with_target(true)
             .init();
-        let client = AListClient::new("http://localhost:5244", "");
-        let result = client
-            .login("admin", "123456", None::<String>)
-            .await
-            .unwrap();
-        // 创建新客户端，使用获取到的token
-        AListClient::new("http://localhost:5244", result.token)
+        let mut client = AListClient::new("http://localhost:5244", "admin", "123456");
+        client.login().await.unwrap();
+        client
     }
 
     #[ignore]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 简化了客户端初始化和认证流程。现在创建客户端时直接提供用户名和密码，无需在登录时重复传递凭据，令牌处理变得更加直观。

- **文档**
  - 精简了部分示例和注释说明，聚焦核心功能，提升整体使用体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->