### PR TITLE
fix: 115 files & mikan calendar bugs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.85.1
           components: rustfmt, clippy
 
       - name: Setup cache

--- a/crates/metadata/src/worker.rs
+++ b/crates/metadata/src/worker.rs
@@ -385,11 +385,11 @@ impl Worker {
         );
 
         // 更新当前放送季
-        if season.is_none() {
+        if calendar.season.is_some() {
             self.dict
                 .set_value(
                     DictCode::CurrentSeasonSchedule,
-                    calendar.season.clone().unwrap_or_default(),
+                    calendar.season.clone().unwrap(),
                 )
                 .await?;
         }

--- a/libs/pan-115/src/file.rs
+++ b/libs/pan-115/src/file.rs
@@ -53,7 +53,7 @@ impl Client {
         resp.basic_resp.is_ok()?;
 
         // FIXME: 115bug, 越界了会永远返回最后一页
-        if offset + limit >= (resp.count + limit) {
+        if offset >= resp.count {
             return Ok(Vec::new());
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了当 offset 超出范围时 API 重复返回最后一页的问题，现在会正确返回空列表。
  * 调整了当前广播季节的更新逻辑，确保仅在日历季节存在时进行更新。

* **Tests**
  * 更新了文件列表相关测试用例，优化了测试输出内容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->